### PR TITLE
cffi 1.15.1

### DIFF
--- a/recipe/0001-Link-to-dl-library.patch
+++ b/recipe/0001-Link-to-dl-library.patch
@@ -1,14 +1,14 @@
---- setup.py	2017-04-06 11:19:47.311893148 +0100
-+++ setup.py	2017-04-06 11:20:07.639160636 +0100
+--- cffi-1.15.1.orig/setup.py	2022-06-30 13:38:43.000000000 -0300
++++ cffi-1.15.1/setup.py	2022-07-02 13:49:37.189516459 -0300
 @@ -1,6 +1,7 @@
- import sys, os
+ import sys, os, platform
  import subprocess
  import errno
 +import sysconfig
  
- 
- sources = ['c/_cffi_backend.c']
-@@ -74,6 +75,10 @@
+ # on Windows we give up and always import setuptools early to fix things for us
+ if sys.platform == "win32":
+@@ -113,6 +114,10 @@
      _ask_pkg_config(library_dirs,       '--libs-only-L', '-L', sysroot=True)
      _ask_pkg_config(extra_link_args,    '--libs-only-other')
      _ask_pkg_config(libraries,          '--libs-only-l', '-l')

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cffi/cffi-{{ version }}.tar.gz
-  sha256: d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9
+  sha256: 920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954
   patches:
     - setup-linux.patch  # [not win]
     - 0001-Link-to-dl-library.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.15.0" %}
+{% set version = "1.15.1" %}
 
 package:
   name: cffi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,13 +6,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cffi/cffi-{{ version }}.tar.gz
-  sha256: 920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954
+  sha256: d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9
   patches:
     - setup-linux.patch  # [not win]
     - 0001-Link-to-dl-library.patch
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   missing_dso_whitelist:
     - $RPATH/ld64.so.1  # [s390x]
@@ -43,7 +43,7 @@ test:
     - pip check
 
 about:
-  home: http://cffi.readthedocs.org/
+  home: https://cffi.readthedocs.org/
   license: MIT
   license_family: MIT
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cffi/cffi-{{ version }}.tar.gz
-  sha256: 920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954
+  sha256: d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9
   patches:
     - setup-linux.patch  # [not win]
     - 0001-Link-to-dl-library.patch

--- a/recipe/setup-linux.patch
+++ b/recipe/setup-linux.patch
@@ -1,17 +1,20 @@
-diff --git setup.py setup.py
-index 40921b8..3f0f35f 100644
---- setup.py
-+++ setup.py
-@@ -5,10 +5,9 @@ import errno
+--- cffi-1.15.1.orig/setup.py	2022-06-30 13:38:43.000000000 -0300
++++ cffi-1.15.1/setup.py	2022-07-02 13:52:32.570495336 -0300
+@@ -9,14 +9,14 @@
  
  sources = ['c/_cffi_backend.c']
  libraries = ['ffi']
 -include_dirs = ['/usr/include/ffi',
 -                '/usr/include/libffi']    # may be changed by pkg-config
 +include_dirs = [os.path.join(sys.prefix, 'include')]
- define_macros = []
+ define_macros = [('FFI_BUILDING', '1')]   # for linking with libffi static library
 -library_dirs = []
 +library_dirs = [os.path.join(sys.prefix, 'lib')]
  extra_compile_args = []
  extra_link_args = []
  
+ 
++
+ def _ask_pkg_config(resultlist, option, result_prefix='', sysroot=False):
+     pkg_config = os.environ.get('PKG_CONFIG','pkg-config')
+     try:


### PR DESCRIPTION
Changelog: a bugfix and update for Windows embedded libffi static lib https://cffi.readthedocs.io/en/latest/whatsnew.html#v1-15-1
Requirements:
- https://foss.heptapod.net/pypy/cffi/-/blob/v1.15.1/setup.py

The package cffi is mentioned inside the packages:
argon2-cffi-bindings | argon2_cffi | bcj-cffi | bcrypt | brotlicffi | brotlipy |  cmarkgfm | cryptography | docker-py | gevent | google-crc32c | jupyter_server | maturin | mercurial | nbclassic | neon | notebook | numba | passlib | persistent | py7zr | pycares | pynacl | pytorch | pytorch-1.7.1 | pytorch-1.8 | pywin32-ctypes | snowflake-connector-python | trio | zstandard |


Actions:
1. Refresh patches
2. Reset build number
3. Fix home url