### PR TITLE
Fix osx closures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 * text=auto
 
-*.patch binary
-*.diff binary
+*.patch text eol=lf
+*.diff text eol=lf
 meta.yaml text eol=lf
 build.sh text eol=lf
 bld.bat text eol=crlf

--- a/recipe/apple-jit.patch
+++ b/recipe/apple-jit.patch
@@ -1,0 +1,13 @@
+Index: cffi-1.15.1/c/_cffi_backend.c
+===================================================================
+--- cffi-1.15.1.orig/c/_cffi_backend.c
++++ cffi-1.15.1/c/_cffi_backend.c
+@@ -87,7 +87,7 @@
+  * This is also used on macOS, provided we are executing on macOS 10.15 or
+  * above.  It's a mess because it needs runtime checks in that case.
+  */
+-#ifdef __NetBSD__
++#if defined(__NetBSD__) || defined(__APPLE__)
+ 
+ # define CFFI_CHECK_FFI_CLOSURE_ALLOC 1
+ # define CFFI_CHECK_FFI_CLOSURE_ALLOC_MAYBE 1

--- a/recipe/apple-jit.patch
+++ b/recipe/apple-jit.patch
@@ -7,7 +7,7 @@ Index: cffi-1.15.1/c/_cffi_backend.c
   * above.  It's a mess because it needs runtime checks in that case.
   */
 -#ifdef __NetBSD__
-+#if defined(__NetBSD__) || defined(__APPLE__)
++#if defined(__NetBSD__) || (defined(__APPLE__) && !defined(FFI_AVAILABLE_APPLE))
  
  # define CFFI_CHECK_FFI_CLOSURE_ALLOC 1
  # define CFFI_CHECK_FFI_CLOSURE_ALLOC_MAYBE 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   patches:
     - setup-linux.patch  # [not win]
     - 0001-Link-to-dl-library.patch
+    - apple-jit.patch  # [osx]
 
 build:
-  number: 2
+  number: 3
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   missing_dso_whitelist:
     - $RPATH/ld64.so.1  # [s390x]


### PR DESCRIPTION
This fixes an issue on Apple's MacOS systems with enabled security features (Big Sur+) in context of callbacks
* bump build number
* add patch file for addressing libffi capability correct for none Apple-libffi on OSX