### PR TITLE
update to 1.17.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.16.0" %}
+{% set version = "1.17.1" %}
 
 package:
   name: cffi
@@ -6,14 +6,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cffi/cffi-{{ version }}.tar.gz
-  sha256: bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0
+  sha256: 1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
   patches:
     - setup-linux.patch  # [not win]
     - 0001-Link-to-dl-library.patch
     - apple-jit.patch  # [osx]
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   missing_dso_whitelist:
     - $RPATH/ld64.so.1  # [s390x]
@@ -29,11 +29,12 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - libffi {{ libffi }} # [not win]
   run:
     - python
-    # set lower bound to avoid hotfix to lower it to <3.3
-    - libffi >=3.4,<3.5 # [not win]
     - pycparser
+    # bounds set through run_exports:
+    - libffi # [not win] 
 
 test:
   imports:


### PR DESCRIPTION
cffi 1.17.1

**Destination channel:** main
### Links

- PKG-5760
- https://github.com/python-cffi/cffi
- https://github.com/python-cffi/cffi/releases

